### PR TITLE
chore: don't build the app if we are destroying the resources

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -68,7 +68,7 @@ export default async (opts: OptionValues) => {
     );
   }
 
-  if (!opts.skipBuild) {
+  if (!opts.skipBuild && !opts.destroy) {
     // run yarn tsc & yarn build for Dockerfile
     Task.section(`Building app`);
     await buildApp();


### PR DESCRIPTION
We don't have to run `yarn tsc && yarn build` if we are destroying everything anyway 👍 