### PR TITLE
chore: Tidy up docs and bump Node ver in Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # backstage-deploy
 
-This package provides a CLI to help deploy Backstage on a specified cloud provider. It uses [Pulumi](https://www.pulumi.com) internally to create the requires resources.
+This package provides a CLI to help deploy Backstage on a specified cloud provider. It uses [Pulumi](https://www.pulumi.com) internally to create the required resources.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # backstage-deploy
 
-This packages provides a CLI to help deploy Backstage on a specified cloud provider.
+This package provides a CLI to help deploy Backstage on a specified cloud provider. It uses [Pulumi](https://www.pulumi.com) internally to create the requires resources.
 
 ## Usage
 
@@ -18,7 +18,7 @@ npx backstage-deploy aws --stack backstage-demo
 
 `backstage-deploy` doesn't use Yarn but PNPM. Please refer to the [install documentation](https://pnpm.io/installation).
 
-After installed, run this command to install the dependencies:
+After installation, run this command to install the dependencies:
 
 ```sh
 pnpm i

--- a/templates/pulumi/Dockerfile
+++ b/templates/pulumi/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:16-bullseye-slim
+FROM --platform=linux/amd64 node:18-bullseye-slim
 
 # Install sqlite3 dependencies. You can skip this if you don't use sqlite3 in the image,
 # in which case you should also move better-sqlite3 to "devDependencies" in package.json.


### PR DESCRIPTION
This PR slightly tidies up the README, and bumps the sample `Dockerfile` to Node 18. It's almost out of LTS, but better matches that of the main Backstage repo for now. Likely to need some more maintenance going forward.