### PR TITLE
Move existence-of-dockerfile check to right before it's used

### DIFF
--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -62,12 +62,6 @@ export default async (opts: OptionValues) => {
     }
   }
 
-  if (!fs.existsSync(opts.dockerfile)) {
-    throw new Error(
-      `Didn't find a Dockerfile at ${opts.dockerfile}. Use --create-dockerfile to create one or use --dockerfile to pass in the path of your Dockerfile.`,
-    );
-  }
-
   const shouldBuildApp = !opts.skipBuild && !opts.destroy && !opts.quickstart;
   if (shouldBuildApp) {
     // run yarn tsc & yarn build for Dockerfile

--- a/src/programs/aws.ts
+++ b/src/programs/aws.ts
@@ -84,6 +84,13 @@ export const AWSProgram = (opts: OptionValues) => {
         create: `docker push ${repositoryUrl}`,
       });
     } else {
+      if (!fs.existsSync(opts.dockerfile)) {
+        throw new Error(
+          `Didn't find a Dockerfile at ${opts.dockerfile}. Use --create-dockerfile to create one, --dockerfile to 
+          pass in the path of an existing Dockerfile, or use --image-uri to use an existing image instead of building one.`,
+        );
+      }
+
       image = new awsx.ecr.Image(`${opts.stack}-image`, {
         repositoryUrl: repository.url,
         path: resolve('.'),

--- a/src/programs/aws.ts
+++ b/src/programs/aws.ts
@@ -41,7 +41,10 @@ function parseOptions(optionStrings: string[]): Record<string, string> {
   for (const str of optionStrings) {
     const [key] = str.split('=', 1);
     const value = str.slice(key.length + 1);
-    if (!key || str[key.length] !== '=') {
+    if (!key) {
+      continue;
+    }
+    if (str[key.length] !== '=') {
       throw new Error(
         `Invalid option '${str}', must be of the format <key>=<value>`,
       );
@@ -56,7 +59,7 @@ export const AWSProgram = (opts: OptionValues) => {
   return async () => {
     const envFilePath = opts.envFile === true ? './.env' : opts.envFile;
     const envs = opts.envFile
-      ? (await fs.readFile(envFilePath, 'utf-8')).trim().split('\n')
+      ? (await fs.readFile(envFilePath, 'utf-8')).split('\n')
       : opts.env;
     const providedEnvironmentVariables = Object.fromEntries(
       Object.entries(parseOptions(envs)).map(([key, value]) => [


### PR DESCRIPTION
This ensures that the check doesn't apply when `--image-uri` is used. Update the error text accordingly.