### PR TITLE
Fix "Invalid option ''" when `.env` file is empty`

### DIFF
--- a/src/programs/aws.ts
+++ b/src/programs/aws.ts
@@ -41,7 +41,10 @@ function parseOptions(optionStrings: string[]): Record<string, string> {
   for (const str of optionStrings) {
     const [key] = str.split('=', 1);
     const value = str.slice(key.length + 1);
-    if (!key || str[key.length] !== '=') {
+    if (!key) {
+      continue;
+    }
+    if (str[key.length] !== '=') {
       throw new Error(
         `Invalid option '${str}', must be of the format <key>=<value>`,
       );
@@ -56,7 +59,7 @@ export const AWSProgram = (opts: OptionValues) => {
   return async () => {
     const envFilePath = opts.envFile === true ? './.env' : opts.envFile;
     const envs = opts.envFile
-      ? (await fs.readFile(envFilePath, 'utf-8')).trim().split('\n')
+      ? (await fs.readFile(envFilePath, 'utf-8')).split('\n')
       : opts.env;
     const providedEnvironmentVariables = Object.fromEntries(
       Object.entries(parseOptions(envs)).map(([key, value]) => [


### PR DESCRIPTION
Even with a `.trim()`, if `.env` if empty, then `.trim().split('\n')` will return `['']`.

Besides, we should probably still ignore empty lines if they appear in the middle of the file.