### PR TITLE
fix: echo npm auth token to .npmrc

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,7 +73,7 @@ jobs:
 
       - name: publish
         run: |
-          pnpm config set npmAuthToken "${{secrets.NPM_TOKEN}}"
+          echo "${{secrets.NPM_TOKEN}}" >> .npmrc 
           pnpm publish --force
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
We assume that `pnpm config set npmAuthToken "${{secrets.NPM_TOKEN}}"` is not adding to `.npmrc` correctly.