### PR TITLE
Remove trailing slash in container service host url if present

### DIFF
--- a/src/programs/aws.ts
+++ b/src/programs/aws.ts
@@ -186,6 +186,7 @@ export const AWSProgram = (opts: OptionValues) => {
           };
 
     /* eslint-disable no-new */
+    const CONTAINER_SERVICE_URL = containerService.url.endsWith("/") ? containerService.url.slice(0, -1) : containerService.url
     new aws.lightsail.ContainerServiceDeploymentVersion(
       `${opts.stack}-deployment`,
       {
@@ -203,7 +204,7 @@ export const AWSProgram = (opts: OptionValues) => {
                     APP_CONFIG_app_baseUrl: containerService.url,
                   }
                 : {
-                    BACKSTAGE_HOST: containerService.url,
+                    BACKSTAGE_HOST: CONTAINER_SERVICE_URL,
                   }),
               ...providedEnvironmentVariables,
               ...(opts.withDb || opts.quickstart ? DB_ENVS : {}),

--- a/src/programs/aws.ts
+++ b/src/programs/aws.ts
@@ -185,8 +185,10 @@ export const AWSProgram = (opts: OptionValues) => {
             DATABASE_PASSWORD: db?.masterPassword,
           };
 
+    const CONTAINER_SERVICE_URL = containerService.url.endsWith('/')
+      ? containerService.url.slice(0, -1)
+      : containerService.url;
     /* eslint-disable no-new */
-    const CONTAINER_SERVICE_URL = containerService.url.endsWith("/") ? containerService.url.slice(0, -1) : containerService.url
     new aws.lightsail.ContainerServiceDeploymentVersion(
       `${opts.stack}-deployment`,
       {

--- a/src/programs/aws.ts
+++ b/src/programs/aws.ts
@@ -186,7 +186,7 @@ export const AWSProgram = (opts: OptionValues) => {
           };
 
     const CONTAINER_SERVICE_URL = containerService.url.apply(url =>
-      url.endsWith('/') ? url.slice(0, -1) : url,
+      url.endsWith('/') ? url.slice(0, -1) : url
     );
     /* eslint-disable no-new */
     new aws.lightsail.ContainerServiceDeploymentVersion(

--- a/src/programs/aws.ts
+++ b/src/programs/aws.ts
@@ -185,9 +185,9 @@ export const AWSProgram = (opts: OptionValues) => {
             DATABASE_PASSWORD: db?.masterPassword,
           };
 
-    const CONTAINER_SERVICE_URL = containerService.url.endsWith('/')
-      ? containerService.url.slice(0, -1)
-      : containerService.url;
+    const CONTAINER_SERVICE_URL = containerService.url.apply(url =>
+      url.endsWith('/') ? url.slice(0, -1) : url,
+    );
     /* eslint-disable no-new */
     new aws.lightsail.ContainerServiceDeploymentVersion(
       `${opts.stack}-deployment`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This change removes trailing backslashes "/" that are included in the Pulumi LightSail Container Service url output.  This would impact frontend API request routing to backend endpoints. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [N/A] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [N/A] Added or updated documentation
- [N/A] Tests for new functionality and regression tests for bug fixes
- [N/A] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
