### PR TITLE
fix: change order of merging configs

### DIFF
--- a/src/programs/aws.ts
+++ b/src/programs/aws.ts
@@ -186,7 +186,7 @@ export const AWSProgram = (opts: OptionValues) => {
           };
 
     const CONTAINER_SERVICE_URL = containerService.url.apply(url =>
-      url.endsWith('/') ? url.slice(0, -1) : url
+      url.endsWith('/') ? url.slice(0, -1) : url,
     );
     /* eslint-disable no-new */
     new aws.lightsail.ContainerServiceDeploymentVersion(

--- a/src/programs/aws.ts
+++ b/src/programs/aws.ts
@@ -185,9 +185,10 @@ export const AWSProgram = (opts: OptionValues) => {
             DATABASE_PASSWORD: db?.masterPassword,
           };
 
-    const CONTAINER_SERVICE_URL = containerService.url.apply(url =>
+    const containerServiceUrl = containerService.url.apply(url =>
       url.endsWith('/') ? url.slice(0, -1) : url,
     );
+
     /* eslint-disable no-new */
     new aws.lightsail.ContainerServiceDeploymentVersion(
       `${opts.stack}-deployment`,
@@ -206,7 +207,7 @@ export const AWSProgram = (opts: OptionValues) => {
                     APP_CONFIG_app_baseUrl: containerService.url,
                   }
                 : {
-                    BACKSTAGE_HOST: CONTAINER_SERVICE_URL,
+                    BACKSTAGE_HOST: containerServiceUrl,
                   }),
               ...providedEnvironmentVariables,
               ...(opts.withDb || opts.quickstart ? DB_ENVS : {}),

--- a/templates/pulumi/Dockerfile
+++ b/templates/pulumi/Dockerfile
@@ -37,4 +37,4 @@ RUN echo "techdocs:" >> app-config.deployment.yaml
 RUN echo "    generator:" >> app-config.deployment.yaml
 RUN echo "        runIn: 'local'" >> app-config.deployment.yaml
 
-CMD ["node", "packages/backend", "--config",  "app-config.deployment.yaml", "--config", "app-config.yaml"]
+CMD ["node", "packages/backend", "--config",  "app-config.yaml", "--config", "app-config.deployment.yaml"]


### PR DESCRIPTION
baseUrl doesn't get replaced:
```sh
❯ yarn backstage-cli config:print --config app-config.deployment.yaml --config app-config.yaml --frontend
yarn run v1.22.19
$ /Users/djamailer/Desktop/projects/backstage-changeset/node_modules/.bin/backstage-cli config:print --config app-config.deployment.yaml --config app-config.yaml --frontend
Loaded config from app-config.deployment.yaml, app-config.yaml
app:
  baseUrl: http://localhost:3000
  title: Scaffolded Backstage App
backend:
  baseUrl: http://localhost:7007
organization:
  name: My Company
integrations:
  github:
    - host: github.com
techdocs:
  builder: local
catalog:
  import:
    entityFilename: catalog-info.yaml
    pullRequestBranchName: backstage-integration

✨  Done in 1.02s.
```

baseUrl gets properly replaced:
```sh
❯ yarn backstage-cli config:print --config app-config.yaml --config app-config.deployment.yaml --frontend
yarn run v1.22.19
$ /Users/djamailer/Desktop/projects/backstage-changeset/node_modules/.bin/backstage-cli config:print --config app-config.yaml --config app-config.deployment.yaml --frontend
Loaded config from app-config.yaml, app-config.deployment.yaml
app:
  title: Scaffolded Backstage App
  baseUrl: http://test
organization:
  name: My Company
backend:
  baseUrl: http://test
integrations:
  github:
    - host: github.com
techdocs:
  builder: local
catalog:
  import:
    entityFilename: catalog-info.yaml
    pullRequestBranchName: backstage-integration

✨  Done in 1.22s.
```