### PR TITLE
chore: remove quickstart from backstage-deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # backstage-deploy
 
+## 0.4.0
+
+### Minor Changes
+
+- Remove all related quickstart functionality. Please refer to the [PR](https://github.com/backstage/backstage-deploy/pull/35) for more information.
+
 ## 0.3.2
 
 - Remove trailing slash in container service host url if present

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backstage-deploy",
   "description": "CLI for Backstage deployment tooling",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "publishConfig": {
     "access": "public"
   },

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -62,7 +62,7 @@ export default async (opts: OptionValues) => {
     }
   }
 
-  const shouldBuildApp = !opts.skipBuild && !opts.destroy && !opts.quickstart;
+  const shouldBuildApp = !opts.skipBuild && !opts.destroy;
   if (shouldBuildApp) {
     // run yarn tsc & yarn build for Dockerfile
     Task.section(`Building app`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,6 @@ const main = (argv: string[]) => {
       './.env',
     )
     .option('--with-db', 'Deploy a Backstage instance with a database', false)
-    .option('--quickstart', 'Deploys a quickstart instance', false)
     .option('--image-uri <image-uri>', 'Url of Docker image')
     .action(cmd => deploy(cmd));
 


### PR DESCRIPTION
Unfortunately, because CNCF owns Backstage, including backstage-deploy and Spotify owns Quickstart. We are not allowed to build in functionality specifically for Quickstart itself!